### PR TITLE
Adding code to precompute exp(-beta*deltaE) for the only possible 5 values. 

### DIFF
--- a/Project-4/include/ising.h
+++ b/Project-4/include/ising.h
@@ -17,9 +17,15 @@ arma::imat initUnorderedSpinMatrix(size_t L, std::uniform_real_distribution<doub
 arma::imat initOrderedSpinMatrix(size_t L);
 
 /*** Perform one Monte Carlo update using The Metropolis Algorithm.
- *   One spin site as chosen at random, and then another random check is made to decide if spin should flip, taking Boltzmann statistics into account. 
- *   Logic taken from section 12.5 of Morten's lecture notes. 
+ *   One spin site as chosen at random, and then another random check is made to decide if spin should flip, taking Boltzmann statistics into account.
+ *   Logic taken from section 12.5 of Morten's lecture notes.
  *   Nomenclature clarification: As this is a single lattice update attempt, one "Monte Carlo cycle" requires N calls to this method.
+ */
+void performOneMonteCarloUpdate(arma::imat &A, size_t L, double beta, std::uniform_real_distribution<double> &uniform_dist, std::mt19937 &generator, std::vector<double>& precomputedExpBeta);
+
+
+/*** Perform one Monte Carlo update using The Metropolis Algorithm.
+ *   The same as the method above but does not utlize the new precomputed beta feature so this one is slower.
  */
 void performOneMonteCarloUpdate(arma::imat& A, size_t L, double beta, std::uniform_real_distribution<double>& uniform_dist, std::mt19937& generator);
 
@@ -38,5 +44,9 @@ double calculateTotalEnergy(arma::imat &A, size_t L);
  *   The unit is just the same dimensionless unit as spins.
  */
 double calculateTotalAbsoluteMagnetization(arma::imat &A, size_t L);
+
+/*** Precompute exp(-beta*deltaE) for the only 5 possible values of deltaE, and for a given T.
+ */
+std::vector<double> precomputeExpBeta(double T);
 
 #endif


### PR DESCRIPTION
Adding this feature in the form of a new additional function performOneMonteCarloUpdate with more parameters. 
If you do not want to adapt to this just use the old performOneMonteCarloUpdate. 

Using this only saves about 10% running time, so consider it optional for early problems. 
0m26.637s -> 0m24.906s for ./problem4.exe 8 4 1000000

Might be more useful for problem 7 and 8, merging the code in now anyway, so it is there ready to be used.
