### PR TITLE
Split solver function into a separate function for setting up Crank Nicolson A and B, and a separate to solve it. Then added unit tests for Crank Nicolson A and B.

### DIFF
--- a/Project-5/Problem-2-3/README.md
+++ b/Project-5/Problem-2-3/README.md
@@ -1,0 +1,11 @@
+# Problem 2-3 manual
+Solvers for Shrödinger equation with Crank Nicelson scheme. 
+
+# Usage
+Small programs for unit testing thereof. 
+- Compile the code with 
+	`g++ crank_nicolson_unit_test.cpp -o crank_nicolson_unit_test.exe ../src/* -I../include/ -std=c++17 -larmadillo`
+	`g++ solver_unit_test.cpp -o solver_unit_test.exe ../src/* -I../include/ -std=c++17 -larmadillo`
+- Run the code with 
+	` ./solver_unit_test.exe`
+	` ./crank_nicolson_unit_test.exe`

--- a/Project-5/Problem-2-3/crank_nicolson_unit_test.cpp
+++ b/Project-5/Problem-2-3/crank_nicolson_unit_test.cpp
@@ -26,7 +26,7 @@ int main()
 
     double dx = (x_max - x_min) / (Nx - 1), dy = (y_max - y_min) / (Ny - 1);
 
-    auto [A, B] = generateCrankNicolsonAB(V_matr, dt, dx, dy, Nx, Ny);
+    auto [A, B] = generate_crank_nicolson_A_and_B(V_matr, dt, dx, dy, Nx, Ny);
 
     std::complex<double> rExpected = 8.000e-04 * 1i;
 

--- a/Project-5/Problem-2-3/crank_nicolson_unit_test.cpp
+++ b/Project-5/Problem-2-3/crank_nicolson_unit_test.cpp
@@ -1,0 +1,42 @@
+
+#include "../include/schrodinger_2d_solver.h"
+#include "../include/auxiliaries.h"
+
+#include <iostream>
+#include <armadillo>
+#include <complex>
+
+using namespace std;
+using namespace std::complex_literals;
+
+int main()
+{
+    // unit test for Crank Nicolson part of schrodinger_solver
+
+    size_t Nx = 5, Ny = 5;
+    arma::vec x_bound = {0, 1}, y_bound = {0, 1};
+    arma::mat V_matr = arma::zeros<arma::mat>(Nx - 2, Ny - 2);
+
+    double dt = 0.0001;
+
+    std::cout << "\n Test 1. \n";
+
+    double x_min = x_bound(0), x_max = x_bound(1);
+    double y_min = y_bound(0), y_max = y_bound(1);
+
+    double dx = (x_max - x_min) / (Nx - 1), dy = (y_max - y_min) / (Ny - 1);
+
+    auto [A, B] = generateCrankNicolsonAB(V_matr, dt, dx, dy, Nx, Ny);
+
+    std::complex<double> rExpected = 8.000e-04 * 1i;
+
+    std::complex<double> error1 = rExpected - (-A(3,0));
+    std::complex<double> error2 = rExpected - (B(3,0));
+
+    double epsilon = 1.0e-15;
+
+    if(std::norm(error1) < epsilon && std::norm(error2) < epsilon)
+    {
+        std::cout << "Test ok!" << std::endl;
+    }
+}

--- a/Project-5/Problem-2-3/crank_nicolson_unit_test.cpp
+++ b/Project-5/Problem-2-3/crank_nicolson_unit_test.cpp
@@ -1,4 +1,3 @@
-
 #include "../include/schrodinger_2d_solver.h"
 #include "../include/auxiliaries.h"
 
@@ -28,15 +27,19 @@ int main()
 
     auto [A, B] = generate_crank_nicolson_A_and_B(V_matr, dt, dx, dy, Nx, Ny);
 
-    std::complex<double> rExpected = 8.000e-04 * 1i;
+    //Testing a couple arbitrary values from matrces for expected values. 
+    //For now only one value from each matrix we know should be r and -r. 
+    //r is defined as i*dt/(2h^2) or for rectangular case i*dt/(2dxdy)
+    //This could/should be extended to check more elemenets. 
+    std::complex<double> rExpected = 1i*dt/(2*dx*dy); //should be 8.000e-04 * 1i;
 
-    std::complex<double> error1 = rExpected - (-A(3,0));
-    std::complex<double> error2 = rExpected - (B(3,0));
+    std::complex<double> error1 = rExpected - (-A(3, 0));
+    std::complex<double> error2 = rExpected - (B(3, 0));
 
     double epsilon = 1.0e-15;
 
-    if(std::norm(error1) < epsilon && std::norm(error2) < epsilon)
+    if (std::norm(error1) < epsilon && std::norm(error2) < epsilon)
     {
-        std::cout << "Test ok!" << std::endl;
+        std::cout << "  Test ok!" << std::endl;
     }
 }

--- a/Project-5/include/schrodinger_2d_solver.h
+++ b/Project-5/include/schrodinger_2d_solver.h
@@ -43,4 +43,16 @@ arma::cx_vec schrodinger_solver(const arma::cx_vec &psi, const std::function<dou
 /// @return Updated wave state vector
 arma::cx_vec schrodinger_solver_cached(arma::cx_cube &cache, const arma::cx_vec &psi, const std::function<double(double, double)> &V, double dt, size_t Nx, size_t Ny, size_t Nt, const arma::vec &x_bound, const arma::vec &y_bound);
 
+/// @brief A function that generates the A and B matrices used in the Crank-Nicolson method for Schrodinger equation;
+/// Diriichlet boundary conditions are assumed;
+/// hbar = 1, m = 0.5 are assumed unit-free
+/// @param V Potential matrix (of size (Nx-2)x(Ny-2))
+/// @param dt Time step
+/// @param dx Step length in x direction (for square matrix this is generally called h)
+/// @param dy Step length in y direction
+/// @param Nx Number of grid points in x direction (for square matrix this is generally called M)
+/// @param Ny Number of grid points in y direction
+/// @return A c++ standard tuple containin two Armadillo matrices
+std::tuple<arma::cx_mat, arma::cx_mat> generateCrankNicolsonAB(const arma::mat &V, double dt, double dx, double dy, size_t Nx, size_t Ny);
+
 #endif

--- a/Project-5/include/schrodinger_2d_solver.h
+++ b/Project-5/include/schrodinger_2d_solver.h
@@ -53,6 +53,6 @@ arma::cx_vec schrodinger_solver_cached(arma::cx_cube &cache, const arma::cx_vec 
 /// @param Nx Number of grid points in x direction (for square matrix this is generally called M)
 /// @param Ny Number of grid points in y direction
 /// @return A c++ standard tuple containin two Armadillo matrices
-std::tuple<arma::cx_mat, arma::cx_mat> generateCrankNicolsonAB(const arma::mat &V, double dt, double dx, double dy, size_t Nx, size_t Ny);
+std::tuple<arma::cx_mat, arma::cx_mat> generate_crank_nicolson_A_and_B(const arma::mat &V, double dt, double dx, double dy, size_t Nx, size_t Ny);
 
 #endif

--- a/Project-5/src/schrodinger_2d_solver.cpp
+++ b/Project-5/src/schrodinger_2d_solver.cpp
@@ -4,13 +4,9 @@
 
 #include <armadillo>
 
-std::tuple<arma::cx_mat, arma::cx_mat> generateAandB(const arma::cx_vec &psi, const arma::mat &V, double dt, size_t Nx, size_t Ny, const arma::vec &x_bound, const arma::vec &y_bound)
+std::tuple<arma::cx_mat, arma::cx_mat> generateCrankNicolsonAB(const arma::mat &V, double dt, double dx, double dy, size_t Nx, size_t Ny)
 {
-    
-    double x_min = x_bound(0), x_max = x_bound(1);
-    double y_min = y_bound(0), y_max = y_bound(1);
 
-    double dx = (x_max - x_min) / (Nx - 1), dy = (y_max - y_min) / (Ny - 1);
     auto im_time_step = arma::cx_double(0, 1) * dt;
 
     // first introduce A and B matrices
@@ -67,9 +63,14 @@ std::tuple<arma::cx_mat, arma::cx_mat> generateAandB(const arma::cx_vec &psi, co
 
 arma::cx_vec schrodinger_solver(const arma::cx_vec &psi, const arma::mat &V, double dt, size_t Nx, size_t Ny, const arma::vec &x_bound, const arma::vec &y_bound)
 {
+    double x_min = x_bound(0), x_max = x_bound(1);
+    double y_min = y_bound(0), y_max = y_bound(1);
+
+    double dx = (x_max - x_min) / (Nx - 1), dy = (y_max - y_min) / (Ny - 1);
+
     arma::cx_mat A, B;
-    std::tie(A, B) = generateAandB(psi, V, dt, Nx, Ny, x_bound, y_bound);
-    //Or if we switch to C++ 17 we can just do: auto [A, B] = generateAandB(psi, V_discrete, dt, Nx, Ny, x_bound, y_bound);
+    std::tie(A, B) = generateCrankNicolsonAB(V, dt, dx, dy, Nx, Ny);
+    //Or if we switch to C++ 17 we can just do: auto [A, B] = generateCrankNicolsonAB(V, dt, dx, dy, Nx, Ny);
 
     // now it takes to solve A psi_new = B * psi
     return arma::solve(A, B * psi);

--- a/Project-5/src/schrodinger_2d_solver.cpp
+++ b/Project-5/src/schrodinger_2d_solver.cpp
@@ -4,7 +4,7 @@
 
 #include <armadillo>
 
-std::tuple<arma::cx_mat, arma::cx_mat> generateCrankNicolsonAB(const arma::mat &V, double dt, double dx, double dy, size_t Nx, size_t Ny)
+std::tuple<arma::cx_mat, arma::cx_mat> generate_crank_nicolson_A_and_B(const arma::mat &V, double dt, double dx, double dy, size_t Nx, size_t Ny)
 {
 
     auto im_time_step = arma::cx_double(0, 1) * dt;
@@ -69,8 +69,8 @@ arma::cx_vec schrodinger_solver(const arma::cx_vec &psi, const arma::mat &V, dou
     double dx = (x_max - x_min) / (Nx - 1), dy = (y_max - y_min) / (Ny - 1);
 
     arma::cx_mat A, B;
-    std::tie(A, B) = generateCrankNicolsonAB(V, dt, dx, dy, Nx, Ny);
-    //Or if we switch to C++ 17 we can just do: auto [A, B] = generateCrankNicolsonAB(V, dt, dx, dy, Nx, Ny);
+    std::tie(A, B) = generate_crank_nicolson_A_and_B(V, dt, dx, dy, Nx, Ny);
+    //Or if we switch to C++ 17 we can just do: auto [A, B] = generate_crank_nicolson_A_and_B(V, dt, dx, dy, Nx, Ny);
 
     // now it takes to solve A psi_new = B * psi
     return arma::solve(A, B * psi);

--- a/Project-5/src/schrodinger_2d_solver.cpp
+++ b/Project-5/src/schrodinger_2d_solver.cpp
@@ -4,10 +4,12 @@
 
 #include <armadillo>
 
-arma::cx_vec schrodinger_solver(const arma::cx_vec &psi, const arma::mat &V, double dt, size_t Nx, size_t Ny, const arma::vec &x_bound, const arma::vec &y_bound)
+std::tuple<arma::cx_mat, arma::cx_mat> generateAandB(const arma::cx_vec &psi, const arma::mat &V, double dt, size_t Nx, size_t Ny, const arma::vec &x_bound, const arma::vec &y_bound)
 {
+    
     double x_min = x_bound(0), x_max = x_bound(1);
     double y_min = y_bound(0), y_max = y_bound(1);
+
     double dx = (x_max - x_min) / (Nx - 1), dy = (y_max - y_min) / (Ny - 1);
     auto im_time_step = arma::cx_double(0, 1) * dt;
 
@@ -59,6 +61,15 @@ arma::cx_vec schrodinger_solver(const arma::cx_vec &psi, const arma::mat &V, dou
         }
         // else is zero already
     }
+
+    return std::make_tuple(A, B);
+}
+
+arma::cx_vec schrodinger_solver(const arma::cx_vec &psi, const arma::mat &V, double dt, size_t Nx, size_t Ny, const arma::vec &x_bound, const arma::vec &y_bound)
+{
+    arma::cx_mat A, B;
+    std::tie(A, B) = generateAandB(psi, V, dt, Nx, Ny, x_bound, y_bound);
+    //Or if we switch to C++ 17 we can just do: auto [A, B] = generateAandB(psi, V_discrete, dt, Nx, Ny, x_bound, y_bound);
 
     // now it takes to solve A psi_new = B * psi
     return arma::solve(A, B * psi);


### PR DESCRIPTION
Splitting enables unit testing on particular formulas from the project spec. Also this is meant to follow principles of Clean Coding to avoid letting one function do too much, and prefer one function being responsible for one thing. 